### PR TITLE
feat/be-get-task-list-filtering: implement get list task api

### DIFF
--- a/src/interceptor/response.interceptor.ts
+++ b/src/interceptor/response.interceptor.ts
@@ -10,11 +10,22 @@ import { map, Observable } from 'rxjs';
 export class ResponseInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     return next.handle().pipe(
-      map((data) => ({
-        statusCode: context.switchToHttp().getResponse().statusCode,
-        message: 'Success',
-        data,
-      })),
+      map((data) => {
+        let response = {
+          statusCode: context.switchToHttp().getResponse().statusCode,
+          message: 'Success',
+          data,
+        };
+
+        if (data && data.meta && data.data) {
+          response = {
+            ...response,
+            ...data,
+          };
+        }
+
+        return response;
+      }),
     );
   }
 }

--- a/src/modules/tasks/dto/detail.dto.ts
+++ b/src/modules/tasks/dto/detail.dto.ts
@@ -1,4 +1,4 @@
-import { Transform } from 'class-transformer';
+import { Expose, Transform } from 'class-transformer';
 import {
   IsDate,
   IsEnum,
@@ -11,31 +11,39 @@ import { TaskStatus } from 'src/generated/prisma/enums';
 
 export class DetailTaskDto {
   @IsUUID()
+  @Expose()
   id: string;
 
   @IsString()
   @IsNotEmpty()
+  @Expose()
   title: string;
 
   @IsString()
   @IsOptional()
+  @Expose()
   description?: string | null;
 
   @IsEnum(TaskStatus)
+  @Expose()
   status: TaskStatus;
 
   @IsUUID()
+  @Expose()
   createdBy: string;
 
   @IsDate()
   @Transform(({ value }) => new Date(value))
+  @Expose()
   expiredAt: Date;
 
   @IsDate()
   @Transform(({ value }) => new Date(value))
+  @Expose()
   createdAt: Date;
 
   @IsDate()
   @Transform(({ value }) => new Date(value))
+  @Expose()
   updatedAt: Date;
 }

--- a/src/modules/tasks/dto/get-list.dto.ts
+++ b/src/modules/tasks/dto/get-list.dto.ts
@@ -4,7 +4,7 @@ import { TaskStatus } from 'src/generated/prisma/enums';
 import { PaginationRequest } from 'src/utils/pagination/request';
 import { DetailTaskDto } from './detail.dto';
 
-export class GetListRequestTaskDto extends PaginationRequest {
+export class GetListTaskRequestDto extends PaginationRequest {
   @IsOptional()
   @IsString()
   title?: string;

--- a/src/modules/tasks/dto/get-list.dto.ts
+++ b/src/modules/tasks/dto/get-list.dto.ts
@@ -1,0 +1,26 @@
+import { PickType } from '@nestjs/mapped-types';
+import { IsDateString, IsEnum, IsOptional, IsString } from 'class-validator';
+import { TaskStatus } from 'src/generated/prisma/enums';
+import { PaginationRequest } from 'src/utils/pagination/request';
+import { DetailTaskDto } from './detail.dto';
+
+export class GetListRequestTaskDto extends PaginationRequest {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsEnum(TaskStatus)
+  status?: TaskStatus;
+
+  @IsOptional()
+  @IsDateString()
+  expiredAt?: string;
+}
+
+export class GetListTaskResponseDto extends PickType(DetailTaskDto, [
+  'id',
+  'title',
+  'status',
+  'expiredAt',
+]) {}

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -6,7 +6,7 @@ import { CurrentUser } from 'src/libs/decorator/current-user.decorator';
 import type { TUserPayload } from '../auth/auth.type';
 import { PaginationResponse } from '../../utils/pagination/response';
 import {
-  GetListRequestTaskDto,
+  GetListTaskRequestDto,
   GetListTaskResponseDto,
 } from './dto/get-list.dto';
 
@@ -28,8 +28,8 @@ export class TasksController {
 
   @Get()
   async getList(
-    @Query() options: GetListRequestTaskDto,
-  ): Promise<PaginationResponse<GetListTaskResponseDto[]>> {
-    return this.tasksService.getList(options);
+    @Query() query: GetListTaskRequestDto,
+  ): Promise<PaginationResponse<GetListTaskResponseDto>> {
+    return this.tasksService.getList(query);
   }
 }

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,9 +1,14 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto, CreateTaskResponseDto } from './dto/create.dto';
 import { JwtAuthGuard } from 'src/guards/auth.guard';
 import { CurrentUser } from 'src/libs/decorator/current-user.decorator';
 import type { TUserPayload } from '../auth/auth.type';
+import { PaginationResponse } from '../../utils/pagination/response';
+import {
+  GetListRequestTaskDto,
+  GetListTaskResponseDto,
+} from './dto/get-list.dto';
 
 @Controller({
   version: '1',
@@ -19,5 +24,12 @@ export class TasksController {
     @CurrentUser() user: TUserPayload,
   ): Promise<CreateTaskResponseDto> {
     return await this.tasksService.create(data, user);
+  }
+
+  @Get()
+  async getList(
+    @Query() options: GetListRequestTaskDto,
+  ): Promise<PaginationResponse<GetListTaskResponseDto[]>> {
+    return this.tasksService.getList(options);
   }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -3,6 +3,12 @@ import { PrismaService } from 'src/libs/database/prisma.service';
 import { TaskStatus } from 'src/generated/prisma/enums';
 import { TUserPayload } from '../auth/auth.type';
 import { CreateTaskRequestDto, CreateTaskResponseDto } from './dto/create.dto';
+import {
+  GetListRequestTaskDto,
+  GetListTaskResponseDto,
+} from './dto/get-list.dto';
+import { PaginationResponse } from 'src/utils/pagination/response';
+import { plainToInstance } from 'class-transformer';
 
 @Injectable()
 export class TasksService {
@@ -24,6 +30,60 @@ export class TasksService {
 
     return {
       id: task.id,
+    };
+  }
+
+  async getList(
+    options: GetListRequestTaskDto,
+  ): Promise<PaginationResponse<GetListTaskResponseDto[]>> {
+    const { limit, page, status, title, expiredAt } = options;
+
+    const take = limit || 10;
+    const skip = ((page || 1) - 1) * take;
+
+    const where: any = {};
+
+    if (status) {
+      where.status = status;
+    }
+
+    if (title) {
+      where.title = {
+        contains: title,
+        mode: 'insensitive',
+      };
+    }
+
+    if (expiredAt) {
+      where.expiredAt = {
+        lte: expiredAt,
+      };
+    }
+
+    const [tasks, total] = await Promise.all([
+      this.prisma.task.findMany({
+        where,
+        skip,
+        take,
+        orderBy: {
+          createdAt: 'desc',
+        },
+      }),
+      this.prisma.task.count({ where }),
+    ]);
+
+    const totalPages = Math.ceil(total / take);
+
+    const taskResult = plainToInstance(GetListTaskResponseDto, tasks, {
+      excludeExtraneousValues: true,
+    });
+
+    return {
+      data: taskResult,
+      meta: {
+        total,
+        totalPages,
+      },
     };
   }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -4,11 +4,12 @@ import { TaskStatus } from 'src/generated/prisma/enums';
 import { TUserPayload } from '../auth/auth.type';
 import { CreateTaskRequestDto, CreateTaskResponseDto } from './dto/create.dto';
 import {
-  GetListRequestTaskDto,
+  GetListTaskRequestDto,
   GetListTaskResponseDto,
 } from './dto/get-list.dto';
 import { PaginationResponse } from 'src/utils/pagination/response';
 import { plainToInstance } from 'class-transformer';
+import { Prisma } from 'src/generated/prisma/client';
 
 @Injectable()
 export class TasksService {
@@ -34,14 +35,14 @@ export class TasksService {
   }
 
   async getList(
-    options: GetListRequestTaskDto,
-  ): Promise<PaginationResponse<GetListTaskResponseDto[]>> {
-    const { limit, page, status, title, expiredAt } = options;
+    query: GetListTaskRequestDto,
+  ): Promise<PaginationResponse<GetListTaskResponseDto>> {
+    const { limit, page, status, title, expiredAt } = query;
 
-    const take = limit || 10;
-    const skip = ((page || 1) - 1) * take;
+    const take = limit;
+    const skip = (page - 1) * take;
 
-    const where: any = {};
+    const where: Prisma.TaskWhereInput = {};
 
     if (status) {
       where.status = status;

--- a/src/utils/pagination/request.ts
+++ b/src/utils/pagination/request.ts
@@ -1,0 +1,16 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class PaginationRequest {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  limit: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page: number;
+}

--- a/src/utils/pagination/request.ts
+++ b/src/utils/pagination/request.ts
@@ -6,11 +6,11 @@ export class PaginationRequest {
   @IsInt()
   @Min(1)
   @IsOptional()
-  limit: number;
+  limit: number = 10;
 
   @Type(() => Number)
   @IsInt()
   @Min(1)
   @IsOptional()
-  page: number;
+  page: number = 1;
 }

--- a/src/utils/pagination/response.ts
+++ b/src/utils/pagination/response.ts
@@ -14,5 +14,5 @@ export class PaginationResponse<T> {
   @Type(() => PaginationMeta)
   meta: PaginationMeta;
 
-  data: T;
+  data: T[];
 }

--- a/src/utils/pagination/response.ts
+++ b/src/utils/pagination/response.ts
@@ -1,0 +1,18 @@
+import { IsNumber, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PaginationMeta {
+  @IsNumber()
+  total: number;
+
+  @IsNumber()
+  totalPages: number;
+}
+
+export class PaginationResponse<T> {
+  @ValidateNested()
+  @Type(() => PaginationMeta)
+  meta: PaginationMeta;
+
+  data: T;
+}


### PR DESCRIPTION
# Description

This PR implements the get list tasks API with filtering and pagination functionality. It allows users to retrieve a paginated list of tasks with optional filters for title, status, and expiration date.

## Linked Issues

#14 

## Changes

- Added `@Expose()` decorators to all fields in `DetailTaskDto` to ensure proper serialization.
- Created `GetListRequestTaskDto` extending `PaginationRequest` with optional filters for title, status, and expiredAt.
- Created `GetListTaskResponseDto` as a subset of `DetailTaskDto` exposing only id, title, status, and expiredAt for the list view.
- Added GET endpoint in `TasksController` for retrieving the list of tasks.
- Implemented `getList` method in `TasksService` with database querying, filtering, and pagination logic.
- Created `PaginationRequest` utility class for common pagination parameters (limit, page).
- Created `PaginationResponse` utility class for paginated API responses with metadata.

## API Endpoint

- Retrieves a paginated list of tasks with optional filtering
- Endpoint: `{BASE_URL}/api/v1/tasks`
- Method: `GET`

Query Params

```ts
{
  limit?: number; // Optional, default 10, min 1
  page?: number; // Optional, default 1, min 1
  title?: string; // Optional, case-insensitive partial match
  status?: TaskStatus; // Optional, enum: PENDING | IN_PROGRESS | COMPLETED
  expiredAt?: string; // Optional, ISO date string, filters tasks with expiredAt <= this date
}
```

Success Response

```ts
{
  meta: {
    total: number; // Total number of tasks matching the filters
    totalPages: number; // Total number of pages
  },
  data: [
    {
      id: string;
      title: string;
      status: TaskStatus; // PENDING | IN_PROGRESS | COMPLETED
      expiredAt: Date;
    }
  ]
}
```

Error Response

```ts
{
  statusCode: number; // e.g., 400
  message: string | string[]; // Validation error messages
  error: string; // e.g., "Bad Request"
}
```