### PR TITLE
feat/be-update-task-api: Implement api for update task and OwnerShipGuard to ensure only owner can edit their task

### DIFF
--- a/src/guards/ownership.guard.ts
+++ b/src/guards/ownership.guard.ts
@@ -1,0 +1,56 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  mixin,
+  Type,
+} from '@nestjs/common';
+import { PrismaService } from 'src/libs/database/prisma.service';
+import { PrismaClient } from 'src/generated/prisma/client';
+
+type ModelName = Exclude<keyof PrismaClient, `$${string}` | symbol>;
+
+export function OwnerShipGuard(modelName: ModelName): Type<CanActivate> {
+  @Injectable()
+  class OwnerGuardMixin implements CanActivate {
+    constructor(private readonly prisma: PrismaService) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const request = context.switchToHttp().getRequest();
+
+      const userId = request.user?.userId;
+      const id = request.params?.id;
+
+      if (!userId) {
+        throw new ForbiddenException('Unauthorized');
+      }
+
+      if (!id) {
+        throw new NotFoundException('Resource id is required');
+      }
+
+      const model: any = this.prisma[modelName];
+
+      const record = await model.findUnique({
+        where: { id },
+        select: { createdBy: true },
+      });
+
+      if (!record) {
+        throw new NotFoundException(`${modelName.toString()} not found`);
+      }
+
+      if (record.createdBy !== userId) {
+        throw new ForbiddenException(
+          `You are not owner of this ${modelName.toString()}`,
+        );
+      }
+
+      return true;
+    }
+  }
+
+  return mixin(OwnerGuardMixin);
+}

--- a/src/modules/tasks/dto/update.dto.ts
+++ b/src/modules/tasks/dto/update.dto.ts
@@ -1,0 +1,11 @@
+import { OmitType, PickType } from '@nestjs/mapped-types';
+import { DetailTaskDto } from './detail.dto';
+
+export class UpdateTaskRequestDto extends OmitType(DetailTaskDto, [
+  'id',
+  'createdBy',
+  'createdAt',
+  'updatedAt',
+]) {}
+
+export class UpdateTaskResponseDto extends PickType(DetailTaskDto, ['id']) {}

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { TasksService } from './tasks.service';
 import { CreateTaskRequestDto, CreateTaskResponseDto } from './dto/create.dto';
 import { JwtAuthGuard } from 'src/guards/auth.guard';
@@ -9,6 +18,7 @@ import {
   GetListTaskRequestDto,
   GetListTaskResponseDto,
 } from './dto/get-list.dto';
+import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dto/update.dto';
 
 @Controller({
   version: '1',
@@ -31,5 +41,13 @@ export class TasksController {
     @Query() query: GetListTaskRequestDto,
   ): Promise<PaginationResponse<GetListTaskResponseDto>> {
     return this.tasksService.getList(query);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() data: UpdateTaskRequestDto,
+  ): Promise<UpdateTaskResponseDto> {
+    return this.tasksService.update(id, data);
   }
 }

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -19,6 +19,7 @@ import {
   GetListTaskResponseDto,
 } from './dto/get-list.dto';
 import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dto/update.dto';
+import { OwnerShipGuard } from 'src/guards/ownership.guard';
 
 @Controller({
   version: '1',
@@ -44,6 +45,7 @@ export class TasksController {
   }
 
   @Put(':id')
+  @UseGuards(OwnerShipGuard('task'))
   async update(
     @Param('id') id: string,
     @Body() data: UpdateTaskRequestDto,

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -10,6 +10,7 @@ import {
 import { PaginationResponse } from 'src/utils/pagination/response';
 import { plainToInstance } from 'class-transformer';
 import { Prisma } from 'src/generated/prisma/client';
+import { UpdateTaskRequestDto, UpdateTaskResponseDto } from './dto/update.dto';
 
 @Injectable()
 export class TasksService {
@@ -29,9 +30,11 @@ export class TasksService {
       },
     });
 
-    return {
-      id: task.id,
-    };
+    const response = plainToInstance(CreateTaskResponseDto, task, {
+      excludeExtraneousValues: true,
+    });
+
+    return response;
   }
 
   async getList(
@@ -86,5 +89,21 @@ export class TasksService {
         totalPages,
       },
     };
+  }
+
+  async update(
+    id: string,
+    data: UpdateTaskRequestDto,
+  ): Promise<UpdateTaskResponseDto> {
+    const updatedData = await this.prisma.task.update({
+      where: { id: id },
+      data,
+    });
+
+    const response = plainToInstance(UpdateTaskResponseDto, updatedData, {
+      excludeExtraneousValues: true,
+    });
+
+    return response;
   }
 }


### PR DESCRIPTION
# Description

Add “Update Task” API endpoint with ownership enforcement so that only the creator can update a task.

## Linked Issues

#12 

## Changes

- Implemented `PUT /api/tasks/:id` to update a task.
- Added `UpdateTaskRequestDto` and `UpdateTaskResponseDto`.
- Added `OwnerShipGuard` to ensure only the task creator can update the task.
- Updated task service to support updating tasks via Prisma and return a properly-shaped response DTO.

## API Endpoint

- **Description:** Update a task by ID (only the task owner can update).
- **Endpoint:** `{BASE_URL}/api/tasks/:id`
- **Method:** `PUT`

### Body

```ts
{
  title: string;
  description?: string | null;
  status: TaskStatus;
  expiredAt: string; // ISO 8601 timestamp
}
```

### Success Response

```ts
{
  id: string;
}
```

### Error Response

```ts
{
  statusCode: number;
  message: string | string[];
  error: string;
}
```

- `403 Forbidden` if the authenticated user is not the owner.
- `404 Not Found` if the task does not exist.
- `401 Unauthorized` if the user is not authenticated.
