### PR TITLE
feat/be-delete-task-api: implement delete task api and add deletedAt field into Task for soft delete feature

### DIFF
--- a/prisma/migrations/20260318095246_add_deleted_at_for_soft_delete_feature/migration.sql
+++ b/prisma/migrations/20260318095246_add_deleted_at_for_soft_delete_feature/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tasks" ADD COLUMN     "deleted_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Task {
   createdBy   String     @map("created_by")
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt @map("updated_at")
+  deletedAt   DateTime?  @map("deleted_at")
 
   @@map("tasks")
 }

--- a/src/modules/tasks/tasks.controller.ts
+++ b/src/modules/tasks/tasks.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -51,5 +52,11 @@ export class TasksController {
     @Body() data: UpdateTaskRequestDto,
   ): Promise<UpdateTaskResponseDto> {
     return this.tasksService.update(id, data);
+  }
+
+  @Delete(':id')
+  @UseGuards(OwnerShipGuard('task'))
+  async delete(@Param('id') id: string): Promise<void> {
+    await this.tasksService.delete(id);
   }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -99,10 +99,7 @@ export class TasksService {
   ): Promise<UpdateTaskResponseDto> {
     const updatedData = await this.prisma.task.update({
       where: { id, deletedAt: null },
-      data: {
-        ...data,
-        updatedAt: new Date(),
-      },
+      data,
     });
 
     const response = plainToInstance(UpdateTaskResponseDto, updatedData, {

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -45,7 +45,9 @@ export class TasksService {
     const take = limit;
     const skip = (page - 1) * take;
 
-    const where: Prisma.TaskWhereInput = {};
+    const where: Prisma.TaskWhereInput = {
+      deletedAt: null,
+    };
 
     if (status) {
       where.status = status;
@@ -96,8 +98,11 @@ export class TasksService {
     data: UpdateTaskRequestDto,
   ): Promise<UpdateTaskResponseDto> {
     const updatedData = await this.prisma.task.update({
-      where: { id: id },
-      data,
+      where: { id, deletedAt: null },
+      data: {
+        ...data,
+        updatedAt: new Date(),
+      },
     });
 
     const response = plainToInstance(UpdateTaskResponseDto, updatedData, {
@@ -105,5 +110,14 @@ export class TasksService {
     });
 
     return response;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prisma.task.update({
+      where: { id },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
   }
 }


### PR DESCRIPTION
# Description

This PR implements a soft delete feature for tasks by adding a `deletedAt` field to the Task model and creating a DELETE API endpoint. The soft delete ensures that tasks are not permanently removed from the database but are marked as deleted and excluded from queries.

## Linked Issues

#13 

## Changes

- Added `deletedAt` field to the Task model in `prisma/schema.prisma`.
- Created a new migration to add the `deleted_at` column to the tasks table.
- Updated the `getList` method in `TasksService` to filter out tasks where `deletedAt` is not null.
- Modified the `update` method to include a check for `deletedAt: null` in the where clause.
- Added a new `delete` method in `TasksService` that sets `deletedAt` to the current timestamp.
- Added a DELETE endpoint in `TasksController` with ownership guard protection.

## API Endpoint

- Description: Soft deletes a task by setting the `deletedAt` timestamp. The task will no longer appear in list queries but remains in the database.
- Endpoint: `{BASE_URL}/api/v1/tasks/:id`
- Method: `DELETE`

Body/Query/Params

```ts
// No body required. The task ID is passed as a URL parameter.
```

Success Response

```ts
{
    "statusCode": 200,
    "message": "Success"
}
```

Error Response

```ts
// HTTP 404 Not Found - Task not found or already deleted
{
  "statusCode": 404,
  "message": "Task not found"
}

// HTTP 403 Forbidden - User does not own the task
{
  "statusCode": 403,
  "message": "Forbidden resource"
}
```