### PR TITLE
feat/be-tag-for-task: implement tag for task feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM node:20-alpine
+FROM node:20-alpine AS builder
 WORKDIR /app
-COPY package*.json ./
-RUN npm install
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
 COPY . .
-RUN npm run build
-CMD ["sh", "-c", "npx prisma migrate dev && node dist/src/main.js"]
+RUN yarn prisma:generate
+RUN yarn build
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/prisma.config.ts ./prisma.config.ts
+COPY --from=builder /app/src/generated/prisma ./src/generated/prisma
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/src/main.js"]

--- a/prisma/migrations/20260331022355_add_task_tag_junction/migration.sql
+++ b/prisma/migrations/20260331022355_add_task_tag_junction/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "tags" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "tags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "task_tag" (
+    "id" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+
+    CONSTRAINT "task_tag_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "tags"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260401024318_change_name_and_unique_tag_title/migration.sql
+++ b/prisma/migrations/20260401024318_change_name_and_unique_tag_title/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deletedAt` on the `tags` table. All the data in the column will be lost.
+  - You are about to drop the column `tagId` on the `task_tag` table. All the data in the column will be lost.
+  - You are about to drop the column `taskId` on the `task_tag` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[title]` on the table `tags` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `tag_id` to the `task_tag` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `task_id` to the `task_tag` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "task_tag" DROP CONSTRAINT "task_tag_tagId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "task_tag" DROP CONSTRAINT "task_tag_taskId_fkey";
+
+-- AlterTable
+ALTER TABLE "tags" DROP COLUMN "deletedAt",
+ADD COLUMN     "deleted_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "task_tag" DROP COLUMN "tagId",
+DROP COLUMN "taskId",
+ADD COLUMN     "tag_id" TEXT NOT NULL,
+ADD COLUMN     "task_id" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tags_title_key" ON "tags"("title");
+
+-- AddForeignKey
+ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260401043534_change_name/migration.sql
+++ b/prisma/migrations/20260401043534_change_name/migration.sql
@@ -4,7 +4,6 @@
   - You are about to drop the column `deletedAt` on the `tags` table. All the data in the column will be lost.
   - You are about to drop the column `tagId` on the `task_tag` table. All the data in the column will be lost.
   - You are about to drop the column `taskId` on the `task_tag` table. All the data in the column will be lost.
-  - A unique constraint covering the columns `[title]` on the table `tags` will be added. If there are existing duplicate values, this will fail.
   - Added the required column `tag_id` to the `task_tag` table without a default value. This is not possible if the table is not empty.
   - Added the required column `task_id` to the `task_tag` table without a default value. This is not possible if the table is not empty.
 
@@ -25,11 +24,8 @@ DROP COLUMN "taskId",
 ADD COLUMN     "tag_id" TEXT NOT NULL,
 ADD COLUMN     "task_id" TEXT NOT NULL;
 
--- CreateIndex
-CREATE UNIQUE INDEX "tags_title_key" ON "tags"("title");
+-- AddForeignKey
+ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "task_tag" ADD CONSTRAINT "task_tag_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "tasks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,18 @@ enum TaskStatus {
   COMPLETED
 }
 
+model Tag {
+  id          String    @id @default(uuid())
+  title       String
+  description String
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+  deletedAt   DateTime?
+  taskTags    TaskTag[]
+
+  @@map("tags")
+}
+
 model Task {
   id          String     @id @default(uuid())
   title       String
@@ -44,8 +56,21 @@ model Task {
   createdAt   DateTime   @default(now()) @map("created_at")
   updatedAt   DateTime   @updatedAt @map("updated_at")
   deletedAt   DateTime?  @map("deleted_at")
+  taskTags    TaskTag[]
 
   @@map("tasks")
+}
+
+model TaskTag {
+  id String @id @default(uuid())
+
+  tag   Tag    @relation(fields: [tagId], references: [id])
+  tagId String
+
+  task   Task   @relation(fields: [taskId], references: [id])
+  taskId String
+
+  @@map("task_tag")
 }
 
 enum TokenType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,7 +37,7 @@ enum TaskStatus {
 
 model Tag {
   id          String @id @default(uuid())
-  title       String @unique
+  title       String
   description String
 
   createdAt DateTime  @default(now()) @map("created_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,14 +15,16 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  name      String
-  password  String
+  id       String @id @default(uuid())
+  email    String @unique
+  name     String
+  password String
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-  tasks     Task[]
-  tokens    Token[]
+
+  tasks  Task[]
+  tokens Token[]
 
   @@map("users")
 }
@@ -34,41 +36,44 @@ enum TaskStatus {
 }
 
 model Tag {
-  id          String    @id @default(uuid())
-  title       String
+  id          String @id @default(uuid())
+  title       String @unique
   description String
-  createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @updatedAt @map("updated_at")
-  deletedAt   DateTime?
-  taskTags    TaskTag[]
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  taskTags TaskTag[]
 
   @@map("tags")
 }
 
 model Task {
-  id          String     @id @default(uuid())
+  id          String   @id @default(uuid())
   title       String
   description String?
-  status      TaskStatus @default(PENDING)
-  user        User       @relation(fields: [creatorId], references: [id])
-  expiredAt   DateTime   @map("expired_at")
-  creatorId   String     @map("creator_id")
-  createdAt   DateTime   @default(now()) @map("created_at")
-  updatedAt   DateTime   @updatedAt @map("updated_at")
-  deletedAt   DateTime?  @map("deleted_at")
-  taskTags    TaskTag[]
+  expiredAt   DateTime @map("expired_at")
+  creatorId   String   @map("creator_id")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  status   TaskStatus @default(PENDING)
+  user     User       @relation(fields: [creatorId], references: [id])
+  taskTags TaskTag[]
 
   @@map("tasks")
 }
 
 model TaskTag {
-  id String @id @default(uuid())
+  id     String @id @default(uuid())
+  tagId  String @map("tag_id")
+  taskId String @map("task_id")
 
-  tag   Tag    @relation(fields: [tagId], references: [id])
-  tagId String
-
-  task   Task   @relation(fields: [taskId], references: [id])
-  taskId String
+  task Task @relation(fields: [taskId], references: [id])
+  tag  Tag  @relation(fields: [tagId], references: [id])
 
   @@map("task_tag")
 }
@@ -79,13 +84,14 @@ enum TokenType {
 }
 
 model Token {
-  id        String    @id @default(uuid())
-  token     String    @unique
-  user      User      @relation(fields: [userId], references: [id])
-  userId    String    @map("user_id")
-  type      TokenType
-  createdAt DateTime  @default(now()) @map("created_at")
-  updatedAt DateTime  @updatedAt @map("updated_at")
+  id        String   @id @default(uuid())
+  token     String   @unique
+  userId    String   @map("user_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  user User      @relation(fields: [userId], references: [id])
+  type TokenType
 
   @@map("tokens")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,35 @@
+import 'dotenv/config';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from 'src/generated/prisma/client';
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL!,
+});
+
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  const tags = [
+    { title: 'Work', description: 'Tasks related to work' },
+    { title: 'Personal', description: 'Personal tasks' },
+    { title: 'Study', description: 'Learning and studying' },
+    { title: 'Health', description: 'Exercise and health-related tasks' },
+    { title: 'Urgent', description: 'High priority tasks' },
+  ];
+
+  await prisma.tag.createMany({
+    data: tags,
+    skipDuplicates: true,
+  });
+
+  console.log('✅ Seed tags done');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { EnvConfigModule } from './config/env-config.module';
 import { TasksModule } from './modules/tasks/tasks.module';
 import { JwtAccessStrategy } from './guards/strategies/jwt-access.strategy';
 import { JwtRefreshStrategy } from './guards/strategies/jwt-refresh.strategy';
+import { TagsModule } from './modules/tags/tags.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { JwtRefreshStrategy } from './guards/strategies/jwt-refresh.strategy';
     AuthModule,
     EnvConfigModule,
     TasksModule,
+    TagsModule,
   ],
   controllers: [AppController],
   providers: [AppService, JwtAccessStrategy, JwtRefreshStrategy],

--- a/src/modules/tags/dto/create-tag.dto.ts
+++ b/src/modules/tags/dto/create-tag.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateTagRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description: string;
+}

--- a/src/modules/tags/dto/get-tag.dto.ts
+++ b/src/modules/tags/dto/get-tag.dto.ts
@@ -1,0 +1,42 @@
+import { Expose, Transform } from 'class-transformer';
+import {
+  IsDate,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+import { PaginationRequestDto } from 'src/libs/dto/pagination.dto';
+
+export class GetTagResponseDto {
+  @IsUUID()
+  @IsString()
+  @Expose()
+  id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Expose()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  @Expose()
+  description: string;
+
+  @IsDate()
+  @Transform(({ value }) => new Date(value))
+  @Expose()
+  createdAt: Date;
+
+  @IsDate()
+  @Transform(({ value }) => new Date(value))
+  @Expose()
+  updatedAt: Date;
+}
+
+export class GetListTagRequestDto extends PaginationRequestDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+}

--- a/src/modules/tags/dto/update-tag.dto.ts
+++ b/src/modules/tags/dto/update-tag.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTagRequestDto } from './create-tag.dto';
+
+export class UpdateTagRequestDto extends PartialType(CreateTagRequestDto) {}

--- a/src/modules/tags/tags.controller.ts
+++ b/src/modules/tags/tags.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+} from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { ResponseIdDto } from '../../libs/dto/response-id.dto';
+import { CreateTagRequestDto } from './dto/create-tag.dto';
+import { UpdateTagRequestDto } from './dto/update-tag.dto';
+import { GetListTagRequestDto, GetTagResponseDto } from './dto/get-tag.dto';
+import { PaginationResponseDto } from 'src/libs/dto/pagination.dto';
+
+@Controller('tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @Post()
+  async create(@Body() data: CreateTagRequestDto): Promise<ResponseIdDto> {
+    return this.tagsService.create(data);
+  }
+
+  @Get()
+  async findAll(
+    @Query() query: GetListTagRequestDto,
+  ): Promise<PaginationResponseDto<GetTagResponseDto>> {
+    return this.tagsService.findAll(query);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string): Promise<GetTagResponseDto> {
+    return this.tagsService.findOne(id);
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id') id: string,
+    @Body() data: UpdateTagRequestDto,
+  ): Promise<ResponseIdDto> {
+    return this.tagsService.update(id, data);
+  }
+
+  @Delete(':id')
+  async remove(@Param('id') id: string): Promise<void> {
+    return this.tagsService.remove(id);
+  }
+}

--- a/src/modules/tags/tags.module.ts
+++ b/src/modules/tags/tags.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
+
+@Module({
+  controllers: [TagsController],
+  providers: [TagsService],
+})
+export class TagsModule {}

--- a/src/modules/tags/tags.service.ts
+++ b/src/modules/tags/tags.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
-import { Prisma, PrismaClient } from 'src/generated/prisma/client';
+import { Prisma } from 'src/generated/prisma/client';
+import { PrismaService } from 'src/libs/database/prisma.service';
 import { PaginationResponseDto } from 'src/libs/dto/pagination.dto';
 import { ResponseIdDto } from '../../libs/dto/response-id.dto';
 import { CreateTagRequestDto } from './dto/create-tag.dto';
@@ -9,7 +10,7 @@ import { UpdateTagRequestDto } from './dto/update-tag.dto';
 
 @Injectable()
 export class TagsService {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(private readonly prisma: PrismaService) {}
   async create(data: CreateTagRequestDto): Promise<ResponseIdDto> {
     const tag = await this.prisma.tag.create({ data });
 
@@ -73,6 +74,24 @@ export class TagsService {
     }
 
     return plainToInstance(GetTagResponseDto, tag, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async findManyByIds(ids: string[]): Promise<GetTagResponseDto[]> {
+    const tags = await this.prisma.tag.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+    });
+
+    if (!tags) {
+      throw new NotFoundException('Task not found!');
+    }
+
+    return plainToInstance(GetTagResponseDto, tags, {
       excludeExtraneousValues: true,
     });
   }

--- a/src/modules/tags/tags.service.ts
+++ b/src/modules/tags/tags.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { Prisma, PrismaClient } from 'src/generated/prisma/client';
+import { PaginationResponseDto } from 'src/libs/dto/pagination.dto';
+import { ResponseIdDto } from '../../libs/dto/response-id.dto';
+import { CreateTagRequestDto } from './dto/create-tag.dto';
+import { GetListTagRequestDto, GetTagResponseDto } from './dto/get-tag.dto';
+import { UpdateTagRequestDto } from './dto/update-tag.dto';
+
+@Injectable()
+export class TagsService {
+  constructor(private readonly prisma: PrismaClient) {}
+  async create(data: CreateTagRequestDto): Promise<ResponseIdDto> {
+    const tag = await this.prisma.tag.create({ data });
+
+    return { id: tag.id };
+  }
+
+  async findAll(
+    query: GetListTagRequestDto,
+  ): Promise<PaginationResponseDto<GetTagResponseDto>> {
+    const { limit, page, title } = query;
+
+    const take = limit;
+    const skip = (page - 1) * take;
+
+    const where: Prisma.TagWhereInput = {
+      deletedAt: null,
+    };
+
+    if (title) {
+      where.title = {
+        contains: title,
+        mode: 'insensitive',
+      };
+    }
+
+    const [tags, total] = await Promise.all([
+      this.prisma.tag.findMany({
+        where,
+        skip,
+        take,
+        orderBy: {
+          createdAt: 'desc',
+        },
+      }),
+      this.prisma.tag.count({ where }),
+    ]);
+
+    const totalPages = Math.ceil(total / take);
+
+    const taskResult = plainToInstance(GetTagResponseDto, tags, {
+      excludeExtraneousValues: true,
+    });
+
+    return {
+      data: taskResult,
+      meta: {
+        total,
+        totalPages,
+        currentPage: page,
+      },
+    };
+  }
+
+  async findOne(id: string): Promise<GetTagResponseDto> {
+    const tag = await this.prisma.tag.findUnique({
+      where: { id, deletedAt: null },
+    });
+
+    if (!tag) {
+      throw new NotFoundException('Task not found!');
+    }
+
+    return plainToInstance(GetTagResponseDto, tag, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async update(id: string, data: UpdateTagRequestDto): Promise<ResponseIdDto> {
+    const updatedTag = await this.prisma.tag.update({
+      where: { id, deletedAt: null },
+      data,
+    });
+
+    return plainToInstance(ResponseIdDto, updatedTag, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.prisma.tag.update({
+      where: { id, deletedAt: null },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+  }
+}

--- a/src/modules/tags/tags.service.ts
+++ b/src/modules/tags/tags.service.ts
@@ -78,24 +78,6 @@ export class TagsService {
     });
   }
 
-  async findManyByIds(ids: string[]): Promise<GetTagResponseDto[]> {
-    const tags = await this.prisma.tag.findMany({
-      where: {
-        id: {
-          in: ids,
-        },
-      },
-    });
-
-    if (!tags) {
-      throw new NotFoundException('Task not found!');
-    }
-
-    return plainToInstance(GetTagResponseDto, tags, {
-      excludeExtraneousValues: true,
-    });
-  }
-
   async update(id: string, data: UpdateTagRequestDto): Promise<ResponseIdDto> {
     const updatedTag = await this.prisma.tag.update({
       where: { id, deletedAt: null },

--- a/src/modules/tags/tags.service.ts
+++ b/src/modules/tags/tags.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { Prisma } from 'src/generated/prisma/client';
 import { PrismaService } from 'src/libs/database/prisma.service';
@@ -12,6 +16,15 @@ import { UpdateTagRequestDto } from './dto/update-tag.dto';
 export class TagsService {
   constructor(private readonly prisma: PrismaService) {}
   async create(data: CreateTagRequestDto): Promise<ResponseIdDto> {
+    const existedTag = await this.prisma.tag.findFirst({
+      where: {
+        title: data.title,
+        deletedAt: null,
+      },
+    });
+
+    if (existedTag) throw new ConflictException('Tag is existed!');
+
     const tag = await this.prisma.tag.create({ data });
 
     return { id: tag.id };

--- a/src/modules/tasks/dto/create.dto.ts
+++ b/src/modules/tasks/dto/create.dto.ts
@@ -5,4 +5,10 @@ export class CreateTaskRequestDto extends PickType(GetDetailTaskResponseDto, [
   'title',
   'description',
   'expiredAt',
+  'tagIds',
 ]) {}
+
+export class CreateManyTaskRequestDto extends PickType(
+  GetDetailTaskResponseDto,
+  ['title', 'description', 'expiredAt'],
+) {}

--- a/src/modules/tasks/dto/get-detail.dto.ts
+++ b/src/modules/tasks/dto/get-detail.dto.ts
@@ -32,7 +32,7 @@ export class GetDetailTaskResponseDto {
   @IsArray()
   @IsUUID('4', { each: true })
   @IsOptional()
-  tagIds: string[];
+  tagIds?: string[];
 
   @IsUUID()
   @Expose()

--- a/src/modules/tasks/dto/get-detail.dto.ts
+++ b/src/modules/tasks/dto/get-detail.dto.ts
@@ -1,5 +1,6 @@
 import { Expose, Transform } from 'class-transformer';
 import {
+  IsArray,
   IsDate,
   IsEnum,
   IsNotEmpty,
@@ -27,6 +28,11 @@ export class GetDetailTaskResponseDto {
   @IsEnum(TaskStatus)
   @Expose()
   status: TaskStatus;
+
+  @IsArray()
+  @IsUUID('4', { each: true })
+  @IsOptional()
+  tagIds: string[];
 
   @IsUUID()
   @Expose()

--- a/src/modules/tasks/dto/get-list.dto.ts
+++ b/src/modules/tasks/dto/get-list.dto.ts
@@ -24,7 +24,7 @@ export class GetListTaskRequestDto extends PaginationRequestDto {
   @IsString()
   @IsUUID()
   @IsOptional()
-  tag?: string;
+  tagId?: string;
 
   @IsOptional()
   @IsDateString()

--- a/src/modules/tasks/dto/get-list.dto.ts
+++ b/src/modules/tasks/dto/get-list.dto.ts
@@ -1,8 +1,16 @@
 import { GetDetailTaskResponseDto } from './get-detail.dto';
 import { PickType } from '@nestjs/mapped-types';
-import { IsDateString, IsEnum, IsOptional, IsString } from 'class-validator';
+import {
+  IsDateString,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 import { PaginationRequestDto } from 'src/libs/dto/pagination.dto';
 import { TaskStatus } from 'src/generated/prisma/enums';
+import { GetTagResponseDto } from 'src/modules/tags/dto/get-tag.dto';
+import { Expose, Type } from 'class-transformer';
 
 export class GetListTaskRequestDto extends PaginationRequestDto {
   @IsOptional()
@@ -12,6 +20,11 @@ export class GetListTaskRequestDto extends PaginationRequestDto {
   @IsOptional()
   @IsEnum(TaskStatus)
   status?: TaskStatus;
+
+  @IsString()
+  @IsUUID()
+  @IsOptional()
+  tag?: string;
 
   @IsOptional()
   @IsDateString()
@@ -23,4 +36,11 @@ export class GetListTaskResponseDto extends PickType(GetDetailTaskResponseDto, [
   'title',
   'status',
   'expiredAt',
-]) {}
+  'tagIds',
+]) {
+  @Expose()
+  @Type(() => TagDto)
+  tags: TagDto[];
+}
+
+class TagDto extends PickType(GetTagResponseDto, ['id', 'title']) {}

--- a/src/modules/tasks/tasks.module.ts
+++ b/src/modules/tasks/tasks.module.ts
@@ -3,6 +3,7 @@ import { TasksService } from './tasks.service';
 import { TasksController } from './tasks.controller';
 
 @Module({
+  imports: [],
   controllers: [TasksController],
   providers: [TasksService],
 })

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -13,7 +13,10 @@ import { PrismaService } from 'src/libs/database/prisma.service';
 import { PaginationResponseDto } from 'src/libs/dto/pagination.dto';
 import { ResponseIdDto } from 'src/libs/dto/response-id.dto';
 import { TUserPayload } from '../auth/auth.type';
-import { CreateTaskRequestDto } from './dto/create.dto';
+import {
+  CreateManyTaskRequestDto,
+  CreateTaskRequestDto,
+} from './dto/create.dto';
 import { GetAIGeneratedTaskResponseDto } from './dto/get-ai-generated-task.dto';
 import { GetDetailTaskResponseDto } from './dto/get-detail.dto';
 import {
@@ -21,6 +24,7 @@ import {
   GetListTaskResponseDto,
 } from './dto/get-list.dto';
 import { UpdateTaskRequestDto } from './dto/update.dto';
+import { TaskTagModel } from 'src/generated/prisma/models';
 
 @Injectable()
 export class TasksService {
@@ -32,13 +36,17 @@ export class TasksService {
   ): Promise<ResponseIdDto> {
     const creatorId: string = user.userId;
 
+    const { tagIds, ...rest } = data;
+
     const task = await this.prisma.task.create({
       data: {
-        ...data,
+        ...rest,
         status: TaskStatus.PENDING,
         creatorId,
       },
     });
+
+    await this.createTaskTag(task.id, tagIds);
 
     const response = plainToInstance(ResponseIdDto, task, {
       excludeExtraneousValues: true,
@@ -48,7 +56,7 @@ export class TasksService {
   }
 
   async createMany(
-    data: CreateTaskRequestDto[],
+    data: CreateManyTaskRequestDto[],
     user: TUserPayload,
   ): Promise<void> {
     const creatorId = user.userId;
@@ -66,7 +74,7 @@ export class TasksService {
     query: GetListTaskRequestDto,
     user: TUserPayload,
   ): Promise<PaginationResponseDto<GetListTaskResponseDto>> {
-    const { limit, page, status, title, expiredAt } = query;
+    const { limit, page, status, title, expiredAt, tag } = query;
 
     const take = limit;
     const skip = (page - 1) * take;
@@ -93,6 +101,13 @@ export class TasksService {
       };
     }
 
+    if (tag) {
+      const taskIds = await this.getTaskForTag(tag);
+
+      where.id = {
+        in: taskIds,
+      };
+    }
     const [tasks, total] = await Promise.all([
       this.prisma.task.findMany({
         where,
@@ -101,14 +116,31 @@ export class TasksService {
         orderBy: {
           createdAt: 'desc',
         },
+        include: {
+          taskTags: {
+            include: {
+              tag: true,
+            },
+          },
+        },
       }),
       this.prisma.task.count({ where }),
     ]);
 
     const totalPages = Math.ceil(total / take);
 
-    const taskResult = plainToInstance(GetListTaskResponseDto, tasks, {
+    const taskResponse = tasks.map((task) => {
+      const { taskTags, ...base } = task;
+
+      return {
+        ...base,
+        tags: taskTags.map((taskTag) => taskTag.tag),
+      };
+    });
+
+    const taskResult = plainToInstance(GetListTaskResponseDto, taskResponse, {
       excludeExtraneousValues: true,
+      enableImplicitConversion: true,
     });
 
     return {
@@ -133,11 +165,16 @@ export class TasksService {
       throw new NotFoundException('Task not found!');
     }
 
+    const tagIds = await this.getTagForTask(id);
+
     const taskRes = plainToInstance(GetDetailTaskResponseDto, task, {
       excludeExtraneousValues: true,
     });
 
-    return taskRes;
+    return {
+      ...taskRes,
+      tagIds,
+    };
   }
 
   async update(
@@ -145,10 +182,14 @@ export class TasksService {
     data: UpdateTaskRequestDto,
     user: TUserPayload,
   ): Promise<ResponseIdDto> {
+    const { tagIds, ...rest } = data;
+
     const updatedData = await this.prisma.task.update({
       where: { id, deletedAt: null, creatorId: user.userId },
-      data,
+      data: rest,
     });
+
+    if (tagIds) await this.updateTagForTask(updatedData.id, tagIds);
 
     const response = plainToInstance(ResponseIdDto, updatedData, {
       excludeExtraneousValues: true,
@@ -186,5 +227,50 @@ export class TasksService {
     } catch (error) {
       throw new BadRequestException(error);
     }
+  }
+
+  private async createTaskTag(taskId: string, tagIds: string[]) {
+    if (tagIds.length > 0) {
+      const data = tagIds.map((tagId: string): Omit<TaskTagModel, 'id'> => {
+        return {
+          taskId,
+          tagId,
+        };
+      });
+
+      await this.prisma.taskTag.createMany({ data });
+    }
+  }
+
+  private async getTagForTask(taskId: string): Promise<string[]> {
+    const taskTags = await this.prisma.taskTag.findMany({
+      where: {
+        taskId,
+      },
+    });
+
+    const tagIds = taskTags.map((taskTag) => taskTag.tagId);
+    return tagIds;
+  }
+
+  private async getTaskForTag(tagId: string): Promise<string[]> {
+    const taskTags = await this.prisma.taskTag.findMany({
+      where: {
+        tagId,
+      },
+    });
+
+    const taskIds = taskTags.map((taskTag) => taskTag.taskId);
+    return taskIds;
+  }
+
+  private async updateTagForTask(taskId: string, tagIds: string[]) {
+    await this.prisma.taskTag.deleteMany({
+      where: {
+        taskId,
+      },
+    });
+
+    await this.createTaskTag(taskId, tagIds);
   }
 }

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -113,13 +113,16 @@ export class TasksService {
         where,
         skip,
         take,
-        orderBy: {
-          createdAt: 'desc',
-        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
         include: {
           taskTags: {
             include: {
               tag: true,
+            },
+            where: {
+              tag: {
+                deletedAt: null,
+              },
             },
           },
         },

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -46,7 +46,7 @@ export class TasksService {
       },
     });
 
-    await this.createTaskTag(task.id, tagIds);
+    await this.createTaskTags(task.id, tagIds);
 
     const response = plainToInstance(ResponseIdDto, task, {
       excludeExtraneousValues: true,
@@ -74,7 +74,7 @@ export class TasksService {
     query: GetListTaskRequestDto,
     user: TUserPayload,
   ): Promise<PaginationResponseDto<GetListTaskResponseDto>> {
-    const { limit, page, status, title, expiredAt, tag } = query;
+    const { limit, page, status, title, expiredAt, tagId } = query;
 
     const take = limit;
     const skip = (page - 1) * take;
@@ -101,8 +101,8 @@ export class TasksService {
       };
     }
 
-    if (tag) {
-      const taskIds = await this.getTaskForTag(tag);
+    if (tagId) {
+      const taskIds = await this.getTaskIdsByTagId(tagId);
 
       where.id = {
         in: taskIds,
@@ -165,7 +165,7 @@ export class TasksService {
       throw new NotFoundException('Task not found!');
     }
 
-    const tagIds = await this.getTagForTask(id);
+    const tagIds = await this.getTagIdsByTaskId(id);
 
     const taskRes = plainToInstance(GetDetailTaskResponseDto, task, {
       excludeExtraneousValues: true,
@@ -189,7 +189,7 @@ export class TasksService {
       data: rest,
     });
 
-    if (tagIds) await this.updateTagForTask(updatedData.id, tagIds);
+    if (tagIds) await this.updateTagIdsByTaskId(updatedData.id, tagIds);
 
     const response = plainToInstance(ResponseIdDto, updatedData, {
       excludeExtraneousValues: true,
@@ -229,8 +229,8 @@ export class TasksService {
     }
   }
 
-  private async createTaskTag(taskId: string, tagIds: string[]) {
-    if (tagIds.length > 0) {
+  private async createTaskTags(taskId: string, tagIds?: string[]) {
+    if (tagIds && tagIds.length > 0) {
       const data = tagIds.map((tagId: string): Omit<TaskTagModel, 'id'> => {
         return {
           taskId,
@@ -242,7 +242,7 @@ export class TasksService {
     }
   }
 
-  private async getTagForTask(taskId: string): Promise<string[]> {
+  private async getTagIdsByTaskId(taskId: string): Promise<string[]> {
     const taskTags = await this.prisma.taskTag.findMany({
       where: {
         taskId,
@@ -253,7 +253,7 @@ export class TasksService {
     return tagIds;
   }
 
-  private async getTaskForTag(tagId: string): Promise<string[]> {
+  private async getTaskIdsByTagId(tagId: string): Promise<string[]> {
     const taskTags = await this.prisma.taskTag.findMany({
       where: {
         tagId,
@@ -264,13 +264,13 @@ export class TasksService {
     return taskIds;
   }
 
-  private async updateTagForTask(taskId: string, tagIds: string[]) {
+  private async updateTagIdsByTaskId(taskId: string, tagIds: string[]) {
     await this.prisma.taskTag.deleteMany({
       where: {
         taskId,
       },
     });
 
-    await this.createTaskTag(taskId, tagIds);
+    await this.createTaskTags(taskId, tagIds);
   }
 }


### PR DESCRIPTION
# Description

Implement Tag feature for Task management, including:
- Add Tag model and TaskTag junction table
- Build full CRUD API for Tag
- Integrate Tag into Task (create, update, filter, response mapping)
- Support filtering tasks by tag
- Add seed script for initial tags
---

## Linked Issues

#21

---

## Changes

### Database
- Add `Tag` model
- Add `TaskTag` junction table (many-to-many relation)
- Add migration for tag system

### Tag Module
- Create `TagsModule`
- Implement Tag CRUD:
  - Create tag
  - Get list (pagination + search by title)
  - Get detail
  - Update
  - Soft delete

### Task Module
- Add `tagIds` support in:
  - Create task
  - Update task
  - Get detail task
- Add `tags` in task list response
- Support filtering tasks by `tag`
- Handle mapping:
  - Task → Tag (via `task_tag`)
- Add internal helpers:
  - `createTaskTag`
  - `updateTagForTask`
  - `getTagForTask`
  - `getTaskForTag`

### DTO Updates
- Add `tagIds` to task DTOs
- Add `tags` field in task list response
- Add tag filter in query

### Seed
- Add `prisma/seed.ts` to generate default tags:
  - Work, Personal, Study, Health, Urgent

---

## API Endpoints

### Tag APIs
- `POST /tags` → create tag
- `GET /tags` → get tag list (pagination + search)
- `GET /tags/:id` → get tag detail
- `PATCH /tags/:id` → update tag
- `DELETE /tags/:id` → soft delete tag

### Task APIs (updated)
- `POST /tasks` → support `tagIds`
- `PATCH /tasks/:id` → update `tagIds`
- `GET /tasks` → support filter by `tag`
- `GET /tasks/:id` → return `tagIds`

---

## Expected Result

- User can create and manage tags
- User can assign multiple tags to a task
- Task list returns associated tags
- Task detail returns `tagIds`
- User can filter tasks by tag
- Tag system works with soft delete and pagination
- Default tags are available after running seed